### PR TITLE
Add a subshell

### DIFF
--- a/src/password-store.sh
+++ b/src/password-store.sh
@@ -477,6 +477,14 @@ cmd_git() {
     fi
 }
 
+cmd_shell() {
+    passphrase
+    while true; do
+        read -p 'pass> ' command
+        run_cmd $command
+    done
+}
+
 #
 # END subcommand functions
 #
@@ -486,6 +494,9 @@ COMMAND="$1"
 
 run_cmd() {
     case "$1" in
+        shell) shift; cmd_shell "$@";;
+        q|quit|exit) shift; exit 0;;
+
         init) shift
             cmd_init "$@"
             ;;

--- a/src/password-store.sh
+++ b/src/password-store.sh
@@ -485,95 +485,95 @@ PROGRAM="${0##*/}"
 COMMAND="$1"
 
 run_cmd() {
-case "$1" in
-    init)
-        shift
-        cmd_init "$@"
-        ;;
+    case "$1" in
+        init)
+            shift
+            cmd_init "$@"
+            ;;
 
-    help|--help)
-        shift
-        cmd_usage "$@"
-        ;;
+        help|--help)
+            shift
+            cmd_usage "$@"
+            ;;
 
-    version|--version)
-        shift
-        cmd_version "$@"
-        ;;
+        version|--version)
+            shift
+            cmd_version "$@"
+            ;;
 
-    show|ls|list)
-        archive_unlock
-        shift
-        cmd_show "$@"
-        ;;
+        show|ls|list)
+            archive_unlock
+            shift
+            cmd_show "$@"
+            ;;
 
-    find|search)
-        archive_unlock
-        shift
-        cmd_find "$@"
-        ;;
+        find|search)
+            archive_unlock
+            shift
+            cmd_find "$@"
+            ;;
 
-    grep)
-        archive_unlock
-        shift
-        cmd_grep "$@"
-        ;;
+        grep)
+            archive_unlock
+            shift
+            cmd_grep "$@"
+            ;;
 
-    insert|add)
-        archive_unlock
-        shift
-        cmd_insert "$@"
-        archive_lock
-        ;;
+        insert|add)
+            archive_unlock
+            shift
+            cmd_insert "$@"
+            archive_lock
+            ;;
 
-    edit)
-        archive_unlock
-        shift
-        cmd_edit "$@"
-        archive_lock
-        ;;
+        edit)
+            archive_unlock
+            shift
+            cmd_edit "$@"
+            archive_lock
+            ;;
 
-    generate)
-        archive_unlock
-        shift
-        cmd_generate "$@"
-        archive_lock
-        ;;
+        generate)
+            archive_unlock
+            shift
+            cmd_generate "$@"
+            archive_lock
+            ;;
 
-    delete|rm|remove)
-        archive_unlock
-        shift
-        cmd_delete "$@"
-        archive_lock
-        ;;
+        delete|rm|remove)
+            archive_unlock
+            shift
+            cmd_delete "$@"
+            archive_lock
+            ;;
 
-    rename|mv)
-        archive_unlock
-        shift
-        cmd_copy_move "move" "$@"
-        archive_lock
-        ;;
+        rename|mv)
+            archive_unlock
+            shift
+            cmd_copy_move "move" "$@"
+            archive_lock
+            ;;
 
-    copy|cp)
-        archive_unlock
-        shift
-        cmd_copy_move "copy" "$@"
-        archive_lock
-        ;;
+        copy|cp)
+            archive_unlock
+            shift
+            cmd_copy_move "copy" "$@"
+            archive_lock
+            ;;
 
-    git)
-        archive_unlock
-        shift
-        cmd_git "$@"
-        archive_lock
-        ;;
+        git)
+            archive_unlock
+            shift
+            cmd_git "$@"
+            archive_lock
+            ;;
 
-    *)
-        archive_unlock
-        COMMAND="show";
-        cmd_show "$@"
-        ;;
-esac
+        *)
+            archive_unlock
+            COMMAND="show";
+            cmd_show "$@"
+            ;;
+    esac
 }
 
 run_cmd "$@"

--- a/src/password-store.sh
+++ b/src/password-store.sh
@@ -486,91 +486,78 @@ COMMAND="$1"
 
 run_cmd() {
     case "$1" in
-        init)
-            shift
+        init) shift
             cmd_init "$@"
             ;;
 
-        help|--help)
-            shift
+        help|--help) shift
             cmd_usage "$@"
             ;;
 
-        version|--version)
-            shift
+        version|--version) shift
             cmd_version "$@"
             ;;
 
-        show|ls|list)
+        show|ls|list) shift
             archive_unlock
-            shift
             cmd_show "$@"
             ;;
 
-        find|search)
+        find|search) shift
             archive_unlock
-            shift
             cmd_find "$@"
             ;;
 
-        grep)
+        grep) shift
             archive_unlock
-            shift
             cmd_grep "$@"
             ;;
 
-        insert|add)
+        insert|add) shift
             archive_unlock
-            shift
             cmd_insert "$@"
             archive_lock
             ;;
 
-        edit)
+        edit) shift
             archive_unlock
-            shift
             cmd_edit "$@"
             archive_lock
             ;;
 
-        generate)
+        generate) shift
             archive_unlock
-            shift
             cmd_generate "$@"
             archive_lock
             ;;
 
-        delete|rm|remove)
+        delete|rm|remove) shift
             archive_unlock
-            shift
             cmd_delete "$@"
             archive_lock
             ;;
 
-        rename|mv)
+        rename|mv) shift
             archive_unlock
-            shift
             cmd_copy_move "move" "$@"
             archive_lock
             ;;
 
-        copy|cp)
+        copy|cp) shift
             archive_unlock
-            shift
             cmd_copy_move "copy" "$@"
             archive_lock
             ;;
 
-        git)
+        git) shift
             archive_unlock
-            shift
             cmd_git "$@"
             archive_lock
             ;;
 
         *)
-            archive_unlock
             COMMAND="show";
+            archive_unlock
             cmd_show "$@"
             ;;
     esac

--- a/src/password-store.sh
+++ b/src/password-store.sh
@@ -484,6 +484,7 @@ cmd_git() {
 PROGRAM="${0##*/}"
 COMMAND="$1"
 
+run_cmd() {
 case "$1" in
     init)
         shift
@@ -573,6 +574,9 @@ case "$1" in
         cmd_show "$@"
         ;;
 esac
+}
+
+run_cmd "$@"
 
 [[ -n $WORKDIR ]] && rm -rf $WORKDIR
 

--- a/src/password-store.sh
+++ b/src/password-store.sh
@@ -480,7 +480,7 @@ cmd_git() {
 cmd_shell() {
     passphrase
     while true; do
-        read -p 'pass> ' command
+        read -e -p 'pass> ' command
         run_cmd $command
     done
 }

--- a/src/password-store.sh
+++ b/src/password-store.sh
@@ -494,83 +494,53 @@ COMMAND="$1"
 
 run_cmd() {
     case "$1" in
-        shell) shift; cmd_shell "$@";;
-        q|quit|exit) shift; exit 0;;
+        shell)
+            shift ; cmd_shell "$@" ;;
 
-        init) shift
-            cmd_init "$@"
-            ;;
+        q|quit|exit)
+            shift ; exit 0 ;;
 
-        help|--help) shift
-            cmd_usage "$@"
-            ;;
+        init)
+            shift ; cmd_init "$@" ;;
 
-        version|--version) shift
-            cmd_version "$@"
-            ;;
+        help|--help)
+            shift ; cmd_usage "$@" ;;
 
-        show|ls|list) shift
-            archive_unlock
-            cmd_show "$@"
-            ;;
+        version|--version)
+            shift ; cmd_version "$@" ;;
 
-        find|search) shift
-            archive_unlock
-            cmd_find "$@"
-            ;;
+        show|ls|list)
+            shift ; archive_unlock ; cmd_show "$@" ;;
 
-        grep) shift
-            archive_unlock
-            cmd_grep "$@"
-            ;;
+        find|search)
+            shift ; archive_unlock ; cmd_find "$@" ;;
 
-        insert|add) shift
-            archive_unlock
-            cmd_insert "$@"
-            archive_lock
-            ;;
+        grep)
+            shift ; archive_unlock ; cmd_grep "$@" ;;
 
-        edit) shift
-            archive_unlock
-            cmd_edit "$@"
-            archive_lock
-            ;;
+        insert|add)
+            shift ; archive_unlock ; cmd_insert "$@" ; archive_lock ;;
 
-        generate) shift
-            archive_unlock
-            cmd_generate "$@"
-            archive_lock
-            ;;
+        edit)
+            shift ; archive_unlock ; cmd_edit "$@" ; archive_lock ;;
 
-        delete|rm|remove) shift
-            archive_unlock
-            cmd_delete "$@"
-            archive_lock
-            ;;
+        generate)
+            shift ; archive_unlock ; cmd_generate "$@" ; archive_lock ;;
 
-        rename|mv) shift
-            archive_unlock
-            cmd_copy_move "move" "$@"
-            archive_lock
-            ;;
+        delete|rm|remove)
+            shift ; archive_unlock ; cmd_delete "$@" ; archive_lock ;;
 
-        copy|cp) shift
-            archive_unlock
-            cmd_copy_move "copy" "$@"
-            archive_lock
-            ;;
+        rename|mv)
+            shift ; archive_unlock ; cmd_copy_move "move" "$@" ; archive_lock ;;
 
-        git) shift
-            archive_unlock
-            cmd_git "$@"
-            archive_lock
-            ;;
+        copy|cp)
+            shift ; archive_unlock ; cmd_copy_move "copy" "$@" ; archive_lock ;;
+
+        git)
+            shift ; archive_unlock ; cmd_git "$@" ; archive_lock ;;
 
         *)
-            COMMAND="show";
-            archive_unlock
-            cmd_show "$@"
-            ;;
+            COMMAND="show" ; archive_unlock ; cmd_show "$@" ;;
     esac
 }
 

--- a/src/password-store.sh
+++ b/src/password-store.sh
@@ -9,7 +9,6 @@ set -o pipefail
 HOMEDIR="${PASSWORD_STORE_DIR:-$HOME/.pw}"
 X_SELECTION="${PASSWORD_STORE_X_SELECTION:-clipboard}"
 CLIP_TIME="${PASSWORD_STORE_CLIP_TIME:-45}"
-SCRIPT_PATH=$( cd $(dirname $0) ; pwd -P )
 
 #
 # BEGIN helper functions
@@ -480,8 +479,7 @@ cmd_git() {
 cmd_shell() {
     run_cmd ls
     while true; do
-        #read -e -p 'pw > ' command
-        command=$(rlwrap -a -c -pGreen -S'pw > ' $SCRIPT_PATH/read.sh)
+        read -e -p 'pw > ' command
         run_cmd $command
     done
 }

--- a/src/read.sh
+++ b/src/read.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Called by rlwrap, because it cannot call directly `read` (it is an internal bash command).
+
+read line
+echo $line

--- a/src/read.sh
+++ b/src/read.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-# Called by rlwrap, because it cannot call directly `read` (it is an internal bash command).
-
-read line
-echo $line


### PR DESCRIPTION
Currently, for each command the user needs to provide the passphrase. This becomes tedious if there are several commands in a row.

With a subshell, the user will be able to enter the passphrase only once, and run as many programs as needed.

Implements #3 
